### PR TITLE
Removed RestAPI.Content.publishCollabDoc as it's no longer exposed

### DIFF
--- a/lib/api.content.js
+++ b/lib/api.content.js
@@ -429,18 +429,6 @@ var download = module.exports.download = function(restCtx, contentId, revisionId
 };
 
 /**
- * Publish a collaborative document.
- *
- * @param  {RestContext}    restCtx             Standard REST Context object that contains the current tenant URL and the current user credentials
- * @param  {String}         contentId           Content id of the content item we're trying to publish.
- * @param  {Function}       callback            Standard callback method
- * @param  {Object}         callback.err        Error object containing error code and error message
- */
-var publishCollabDoc = module.exports.publishCollabDoc = function(restCtx, contentId, callback) {
-    RestUtil.RestRequest(restCtx, '/api/content/' + RestUtil.encodeURIComponent(contentId) + '/publish', 'POST', null, callback);
-};
-
-/**
  * Join a collaborative document.
  *
  * @param  {RestContext}    restCtx             Standard REST Context object that contains the current tenant URL and the current user credentials


### PR DESCRIPTION
Removed the publishCollabDoc as it is no longer necessary due to https://github.com/oaeproject/Hilary/pull/813
